### PR TITLE
Feature(role based and notification): add role based access and notifcation flow for successful registration and login

### DIFF
--- a/dalscooter-frontend/src/pages/MFAQuestionPage.jsx
+++ b/dalscooter-frontend/src/pages/MFAQuestionPage.jsx
@@ -25,8 +25,8 @@ export default function MFAQuestionPage() {
     setLoading(true);
     try {
       const next = await respondChallenge({ answer });
-
-      if (next === 'CAESAR') {
+      console.log("THIS IS THE NEXT:", next)
+      if (next.type === 'CAESAR') {
         navigate('/mfa-caesar');
       } else if (next === null) {
         navigate('/customer-home');

--- a/dalscooter-frontend/src/pages/OTPPage.jsx
+++ b/dalscooter-frontend/src/pages/OTPPage.jsx
@@ -1,4 +1,3 @@
-// src/pages/OTPPage.jsx
 import React, { useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import Navbar from '../components/Navbar';
@@ -46,7 +45,7 @@ export default function OTPPage() {
         {error && <p className="error">{error}</p>}
         <form onSubmit={handleSubmit}>
           <label>
-            Email
+            Email <br /><br />
             <input
               type="email"
               value={email}
@@ -55,7 +54,7 @@ export default function OTPPage() {
             />
           </label>
           <label>
-            Confirmation Code
+            Confirmation Code <br /><br />
             <input
               value={code}
               onChange={e => setCode(e.target.value)}
@@ -66,8 +65,15 @@ export default function OTPPage() {
             {loading ? 'Confirming…' : 'Confirm'}
           </button>
         </form>
-        <button onClick={handleResend}>Resend Code</button>
+
+        <button
+          onClick={handleResend}
+          style={{ marginTop: '1rem' }}
+        >
+          Resend Code
+        </button>
       </div>
     </>
   );
 }
+

--- a/dalscooter-frontend/src/pages/RegisterPage.jsx
+++ b/dalscooter-frontend/src/pages/RegisterPage.jsx
@@ -12,7 +12,10 @@ export default function RegisterPage() {
     email: '',
     password: '',
     question: '',
-    answer: ''
+    answer: '',
+    role: '',
+    caesarText: '',
+    shiftKey: ''
   });
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
@@ -33,8 +36,10 @@ export default function RegisterPage() {
         name: form.name.trim(),
         email: form.email.toLowerCase().trim(),
         question: form.question,
-        answer: form.answer.trim().toLowerCase()
-        
+        answer: form.answer.trim().toLowerCase(),
+        role: form.role,
+        caesarText: form.caesarText,
+        shiftKey: form.shiftKey
       });
       navigate('/login');
     } catch (err) {
@@ -53,30 +58,103 @@ export default function RegisterPage() {
         {error && <p className="error">{error}</p>}
         <form onSubmit={handleSubmit}>
           <label>
-            Full Name
-            <input name="name" value={form.name} onChange={handleChange} required />
+            Full Name<br />
+            <input
+              name="name"
+              value={form.name}
+              onChange={handleChange}
+              required
+              style={{ marginTop: '0.25rem' }}
+            />
           </label>
+
           <label>
-            Email
-            <input name="email" type="email" value={form.email} onChange={handleChange} required />
+            Email<br />
+            <input
+              name="email"
+              type="email"
+              value={form.email}
+              onChange={handleChange}
+              required
+              style={{ marginTop: '0.25rem' }}
+            />
           </label>
+
           <label>
-            Password
-            <input name="password" type="password" value={form.password} onChange={handleChange} required />
+            Password<br />
+            <input
+              name="password"
+              type="password"
+              value={form.password}
+              onChange={handleChange}
+              required
+              style={{ marginTop: '0.25rem' }}
+            />
           </label>
+
           <label>
-            Security Question
-            <select name="question" value={form.question} onChange={handleChange} required>
+            Security Question<br />
+            <select
+              name="question"
+              value={form.question}
+              onChange={handleChange}
+              required
+              style={{ marginTop: '0.25rem' }}
+            >
               <option value="">Select a question</option>
               <option value="What is your pet’s name?">What is your pet’s name?</option>
               <option value="What is your mother’s maiden name?">What is your mother’s maiden name?</option>
               <option value="What is your favorite color?">What is your favorite color?</option>
             </select>
           </label>
+
           <label>
-            Your Answer
-            <input name="answer" value={form.answer} onChange={handleChange} required />
+            Your Answer<br />
+            <input
+              name="answer"
+              value={form.answer}
+              onChange={handleChange}
+              required
+              style={{ marginTop: '0.25rem' }}
+            />
           </label>
+
+          <label>
+            I am signing up as<br />
+            <select
+              name="role"
+              value={form.role}
+              onChange={handleChange}
+              required
+              style={{ marginTop: '0.25rem' }}
+            >
+              <option value="">Select a role</option>
+              <option value="RegisteredCustomer">User</option>
+              <option value="FranchiseOperator">Franchise Owner</option>
+            </select>
+          </label>
+          <label>
+            Caesar Text<br />
+            <input
+              name="caesarText"
+              value={form.caesarText}
+              onChange={handleChange}
+              placeholder="Enter text to encrypt"
+              style={{ marginTop: '0.25rem' }}
+            />
+          </label>
+          <label>
+            Shift Key<br />
+            <input
+              name="shiftKey"
+              type="number"
+              value={form.shiftKey}
+              onChange={handleChange}
+              placeholder="e.g. 3"
+              style={{ marginTop: '0.25rem' }}
+            />
+          </label>
+
           <button type="submit" disabled={loading}>
             {loading ? 'Registering…' : 'Register'}
           </button>

--- a/lambda-functions/create_auth.py
+++ b/lambda-functions/create_auth.py
@@ -25,7 +25,7 @@ def lambda_handler(event, context):
 
     elif len(session) == 3 and session[2]['challengeName'] == "CUSTOM_CHALLENGE" and session[1]['challengeResult']:
         item       = caesar_table.get_item(Key={'user_id': user}).get('Item', {})
-        cipher     = item.get('challenge_text', '')
+        cipher     = item.get('challengeText', '')
         plaintext  = item.get('plainText', '').strip().lower()
 
         event['response']['publicChallengeParameters'] = {

--- a/lambda-functions/define_auth.py
+++ b/lambda-functions/define_auth.py
@@ -13,7 +13,7 @@ def lambda_handler(event, context):
         event['response']['issueTokens']        = False
         event['response']['failAuthentication'] = False
 
-    elif len(session) == 3 and session[2]['challengeName'] == "CUSTOM_CHALLENGE" and session[1]['challengeResult']:
+    elif len(session) == 3 and session[2]['challengeName'] == "CUSTOM_CHALLENGE" and session[2]['challengeResult']:
         event['response']['challengeName']      = 'CUSTOM_CHALLENGE'
         event['response']['issueTokens']        = False
         event['response']['failAuthentication'] = False

--- a/lambda-functions/notification_consumer.py
+++ b/lambda-functions/notification_consumer.py
@@ -1,0 +1,43 @@
+import os
+import json
+import boto3
+
+ses            = boto3.client('ses')
+FROM_ADDRESS   = os.environ['SES_FROM_ADDRESS']
+TEMPLATE_NAME  = os.environ['SES_TEMPLATE_NAME']
+
+def lambda_handler(event, context):
+    for record in event['Records']:
+        try:
+            envelope = json.loads(record['body'])
+        except json.JSONDecodeError:
+            print("Malformed SQS message, skipping:", record['body'])
+            continue
+
+        try:
+            payload = json.loads(envelope.get('Message', '{}'))
+        except json.JSONDecodeError:
+            print("Malformed SNS Message field, skipping:", envelope.get('Message'))
+            continue
+
+        email   = payload.get('email')
+        subject = payload.get('subject', 'Notification from DALScooter')
+        message = payload.get('message', '')
+
+        if not email:
+            print("No email address provided, skipping:", payload)
+            continue
+
+        try:
+            ses.send_templated_email(
+                Source       = FROM_ADDRESS,
+                Destination  = {'ToAddresses': [email]},
+                Template     = TEMPLATE_NAME,
+                TemplateData = json.dumps({
+                  'subject': subject,
+                  'message': message
+                })
+            )
+            print(f"Templated notification sent to {email}")
+        except Exception as e:
+            print(f"Error sending templated email to {email}: {e}")

--- a/lambda-functions/verify_auth.py
+++ b/lambda-functions/verify_auth.py
@@ -1,31 +1,54 @@
-import boto3
-import hashlib
 import os
+import json
+import boto3
 
-# DynamoDB tables (hard-coded names)
-dynamodb = boto3.resource('dynamodb')
-qa_table = dynamodb.Table('SecurityQA')
+dynamodb     = boto3.resource('dynamodb')
+qa_table     = dynamodb.Table('SecurityQA')
 caesar_table = dynamodb.Table('CaesarChallenge')
+
+sns_client   = boto3.client('sns')
+LOGIN_TOPIC  = os.environ.get('LOGIN_TOPIC_ARN')
 
 
 def lambda_handler(event, context):
-    user = event['userName']
-    answer = event['request']['challengeAnswer']
+    user_id  = event['userName']
+    answer   = event['request']['challengeAnswer']
     metadata = event['request'].get('privateChallengeParameters', {})
-    passed = False
+    passed   = False
 
     if metadata.get('challenge_type') == 'QA':
-        # fetch correct answer
-        item = qa_table.get_item(Key={'user_id': user}).get('Item', {})
+        item    = qa_table.get_item(Key={'user_id': user_id}).get('Item', {})
         correct = item.get('secAnswer', '').strip().lower()
-        passed = (answer.strip().lower() == correct)
-        print(f"Expected answer: {correct}", passed)
+        passed  = (answer.strip().lower() == correct)
 
     elif metadata.get('challenge_type') == 'CAESAR':
-        # expected_answer was the plaintext
         correct = metadata.get('expected_answer', '').strip().lower()
-        passed = (answer.strip().lower() == correct)
-        print(f"Expected answer: {correct}", passed)
+        passed  = (answer.strip().lower() == correct)
 
     event['response']['answerCorrect'] = passed
+
+    if metadata.get('challenge_type') == 'CAESAR' and passed and LOGIN_TOPIC:
+        email   = event['request']['userAttributes'].get('email')
+        payload = {
+            'email':   email,
+            'subject': 'Welcome Back to DALScooter!',
+            'message': (
+                f"Hi {user_id},\n\n"
+                "You’ve successfully logged into your DALScooter account.\n\n"
+                "What’s new:\n"
+                " • Quick-start rides right from the app home screen\n"
+                " • Real-time trip tracking and history\n"
+                " • Enhanced rewards dashboard to earn more with every ride\n\n"
+                "If this wasn’t you, please reset your password immediately.\n\n"
+                "Happy riding!\n"
+            )
+        }
+        try:
+            sns_client.publish(
+                TopicArn=LOGIN_TOPIC,
+                Message=json.dumps(payload)
+            )
+        except Exception as e:
+            print(f"Error sending SNS login notification: {e}")
+
     return event

--- a/terraform/Cognito.tf
+++ b/terraform/Cognito.tf
@@ -16,6 +16,44 @@ resource "aws_cognito_user_pool" "main" {
     attribute_data_type = "String"
   }
 
+  schema {
+    name = "secQuestion"
+    attribute_data_type = "String"
+    mutable = true
+    string_attribute_constraints {
+      min_length = 1
+      max_length = 256
+    }
+  }
+
+  schema {
+    name = "secAnswer"
+    attribute_data_type = "String"
+    mutable = true
+    string_attribute_constraints {
+      min_length = 1
+      max_length = 256
+    }
+  }
+
+  schema {
+    name = "role"
+    attribute_data_type = "String"
+    mutable = true
+  }
+
+  schema {
+    name = "caesarText"
+    attribute_data_type = "String"
+    mutable = true
+  }
+  schema {
+    name = "shiftKey"
+    attribute_data_type = "Number"
+    required = false
+    mutable = true
+  }
+
   password_policy {
     minimum_length = 8
     require_lowercase = true
@@ -65,4 +103,17 @@ resource "aws_lambda_permission" "allow_cognito_verify" {
   function_name = aws_lambda_function.lambda["verify_auth"].function_name
   principal     = "cognito-idp.amazonaws.com"
   source_arn    = aws_cognito_user_pool.main.arn
+}
+resource "aws_cognito_user_group" "registered_customer" {
+  name         = "RegisteredCustomer"
+  user_pool_id = aws_cognito_user_pool.main.id
+  description  = "Users who have signed up and passed MFA—can book e-bikes and use the virtual assistant"  
+  precedence   = 50
+}
+
+resource "aws_cognito_user_group" "franchise_operator" {
+  name         = "FranchiseOperator"
+  user_pool_id = aws_cognito_user_pool.main.id
+  description  = "Admin users—can add/update scooters, view all bookings, and communicate with customers"
+  precedence   = 10
 }

--- a/terraform/DynamoDB.tf
+++ b/terraform/DynamoDB.tf
@@ -8,18 +8,6 @@ resource "aws_dynamodb_table" "users" {
     type = "S"
   }
 }
-
-resource "aws_dynamodb_table" "user_data" {
-  name         = "UserData"
-  billing_mode = "PAY_PER_REQUEST"
-  hash_key     = "user_id"
-
-  attribute {
-    name = "user_id"
-    type = "S"
-  }
-}
-
 resource "aws_dynamodb_table" "security_questions" {
   name         = "SecurityQA"
   billing_mode = "PAY_PER_REQUEST"
@@ -38,28 +26,6 @@ resource "aws_dynamodb_table" "caesar_cipher" {
 
   attribute {
     name = "user_id"
-    type = "S"
-  }
-}
-
-resource "aws_dynamodb_table" "booking_info" {
-  name         = "BookingInfo"
-  billing_mode = "PAY_PER_REQUEST"
-  hash_key     = "booking_code"
-
-  attribute {
-    name = "booking_code"
-    type = "S"
-  }
-}
-
-resource "aws_dynamodb_table" "user_concerns" {
-  name         = "UserConcerns"
-  billing_mode = "PAY_PER_REQUEST"
-  hash_key     = "ticket_id"
-
-  attribute {
-    name = "ticket_id"
     type = "S"
   }
 }

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -17,30 +17,6 @@ resource "aws_iam_role_policy_attachment" "lambda_dynamo_access" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess"
 }
 
-resource "aws_iam_role" "lex_lambda_role" {
-  name = "lex_lambda_execution_role"
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17",
-    Statement = [{
-      Action = "sts:AssumeRole",
-      Effect = "Allow",
-      Principal = {
-        Service = "lambda.amazonaws.com"
-      }
-    }]
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "lex_lambda_policy" {
-  role       = aws_iam_role.lex_lambda_role.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess"
-}
-
-resource "aws_iam_role_policy_attachment" "lambda_basic_exec" {
-  role       = aws_iam_role.lex_lambda_role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-}
-
 resource "aws_iam_role_policy_attachment" "lambda_basic_exec_mfa" {
   role       = aws_iam_role.lambda_role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -77,4 +53,22 @@ resource "aws_lambda_permission" "post_confirmation_permission" {
   function_name = aws_lambda_function.lambda["post_confirmation"].function_name
   principal     = "cognito-idp.amazonaws.com"
   source_arn    = aws_cognito_user_pool.main.arn
+}
+
+resource "aws_iam_role_policy" "allow_admin_add_user_to_group" {
+  name = "AllowAdminAddUserToGroup"
+  role = aws_iam_role.lambda_role.name
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect   = "Allow",
+        Action   = [
+          "cognito-idp:AdminAddUserToGroup",
+          "cognito-idp:AdminRemoveUserFromGroup"
+        ],
+        Resource = aws_cognito_user_pool.main.arn
+      }
+    ]
+  })
 }

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -1,9 +1,10 @@
 locals {
   lambdas = {
-    define_auth        = "${path.module}/../lambda-functions/define_auth.py"
-    create_auth        = "${path.module}/../lambda-functions/create_auth.py"
-    verify_auth        = "${path.module}/../lambda-functions/verify_auth.py"
-    post_confirmation  = "${path.module}/../lambda-functions/post_confirmation.py"
+    define_auth           = "${path.module}/../lambda-functions/define_auth.py"
+    create_auth           = "${path.module}/../lambda-functions/create_auth.py"
+    verify_auth           = "${path.module}/../lambda-functions/verify_auth.py"
+    post_confirmation     = "${path.module}/../lambda-functions/post_confirmation.py"
+    notification_consumer = "${path.module}/../lambda-functions/notification_consumer.py"
   }
 }
 
@@ -16,10 +17,49 @@ data "archive_file" "lambda_zips" {
 
 resource "aws_lambda_function" "lambda" {
   for_each         = data.archive_file.lambda_zips
-  function_name    = each.key
+  function_name    = each.key == "notification_consumer" ? "notificationConsumer" : each.key
   filename         = each.value.output_path
   handler          = "${replace(each.key, "_check", "")}.lambda_handler"
   runtime          = "python3.9"
   role             = aws_iam_role.lambda_role.arn
   source_code_hash = each.value.output_base64sha256
+
+  environment {
+    variables = each.key == "notification_consumer" ? {
+      SES_FROM_ADDRESS = "csci5408@gmail.com"
+      SES_TEMPLATE_NAME = "NotificationTemplate"
+    } : {
+      REGISTRATION_TOPIC_ARN = aws_sns_topic.registration_topic.arn
+      LOGIN_TOPIC_ARN        = aws_sns_topic.login_topic.arn
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "lambda_sqs_permissions" {
+  name = "LambdaSQSPermissions"
+  role = aws_iam_role.lambda_role.name
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect   = "Allow",
+        Action   = [
+          "sqs:ReceiveMessage",
+          "sqs:DeleteMessage",
+          "sqs:GetQueueAttributes",
+          "sqs:GetQueueUrl",
+          "sqs:ChangeMessageVisibility"
+        ],
+        Resource = aws_sqs_queue.notification_queue.arn
+      }
+    ]
+  })
+}
+
+resource "aws_lambda_event_source_mapping" "consumer_sqs" {
+  event_source_arn = aws_sqs_queue.notification_queue.arn
+  function_name    = aws_lambda_function.lambda["notification_consumer"].arn
+  batch_size       = 1
+  enabled          = true
 }

--- a/terraform/sns-sqs.tf
+++ b/terraform/sns-sqs.tf
@@ -1,0 +1,149 @@
+variable "notification_queue_name" {
+  description = "Name of the SQS queue for user notifications"
+  type        = string
+  default     = "user-notifications-queue"
+}
+
+resource "aws_sqs_queue" "notification_queue" {
+  name                         = var.notification_queue_name
+  visibility_timeout_seconds   = 30
+  message_retention_seconds    = 1209600
+}
+
+resource "aws_sns_topic" "registration_topic" {
+  name = "user-registration-topic"
+}
+
+resource "aws_sns_topic" "login_topic" {
+  name = "user-login-topic"
+}
+
+variable "test_emails" {
+  description = "List of email addresses to verify in SES sandbox"
+  type        = list(string)
+  default     = []
+}
+
+resource "aws_ses_email_identity" "test_recipients" {
+  for_each = toset(var.test_emails)
+  email    = each.key
+}
+
+
+resource "aws_sqs_queue_policy" "notification_queue_policy" {
+  queue_url = aws_sqs_queue.notification_queue.id
+  policy    = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect    = "Allow",
+        Principal = { Service = "sns.amazonaws.com" },
+        Action    = "sqs:SendMessage",
+        Resource  = aws_sqs_queue.notification_queue.arn,
+        Condition = {
+          ArnEquals = {
+            "aws:SourceArn": [
+              aws_sns_topic.registration_topic.arn,
+              aws_sns_topic.login_topic.arn
+            ]
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_ses_email_identity" "from_address" {
+  email = "csci5408@gmail.com"
+}
+
+resource "aws_sns_topic_subscription" "registration_to_queue" {
+  topic_arn = aws_sns_topic.registration_topic.arn
+  protocol  = "sqs"
+  endpoint  = aws_sqs_queue.notification_queue.arn
+}
+
+resource "aws_sns_topic_subscription" "login_to_queue" {
+  topic_arn = aws_sns_topic.login_topic.arn
+  protocol  = "sqs"
+  endpoint  = aws_sqs_queue.notification_queue.arn
+}
+
+
+resource "aws_iam_role_policy" "post_confirmation_sns_publish" {
+  name = "PostConfirmationSNSPublish"
+  role = aws_iam_role.lambda_role.name
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect   = "Allow",
+        Action   = "sns:Publish",
+        Resource = aws_sns_topic.registration_topic.arn
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "verify_auth_sns_publish" {
+  name = "VerifyAuthSNSPublish"
+  role = aws_iam_role.lambda_role.name
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect   = "Allow",
+        Action   = "sns:Publish",
+        Resource = aws_sns_topic.login_topic.arn
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "lambda_ses_send" {
+  name = "LambdaSESSend"
+  role = aws_iam_role.lambda_role.name
+  policy = jsonencode({
+    Version   = "2012-10-17",
+    Statement = [{
+      Effect   = "Allow",
+      Action   = ["ses:SendEmail", "ses:SendRawEmail", "ses:SendTemplatedEmail", "ses:SendBulkTemplatedEmail"],
+      Resource = "*"
+    }]
+  })
+}
+
+resource "aws_ses_template" "notification_template" {
+  name    = "NotificationTemplate"
+  subject = "{{subject}}"
+
+  html = <<-EOF
+    <html>
+      <body style="font-family:Arial, sans-serif; background-color:#f9f9f9; padding:20px;">
+        <div style="max-width:600px; margin:0 auto; background-color:#ffffff; padding:20px; border-radius:8px; box-shadow:0 2px 4px rgba(0,0,0,0.1);">
+          <h2 style="color:#333333; text-align:center;">DALScooter Notification</h2>
+          <div style="color:#555555; font-size:16px; line-height:1.5;">
+            {{message}}
+          </div>
+          <p style="margin-top:30px; color:#777777; font-size:14px;">
+            Best regards,<br />
+            DALScooter Team
+          </p>
+          <hr style="border:none;border-top:1px solid #E2E8F0;margin:20px 0;" />
+          <p style="text-align:center; color:#A0AEC0; font-size:12px; margin:0;">
+            Your sustainable ride-sharing solution
+          </p>
+        </div>
+      </body>
+    </html>
+  EOF
+
+  text = <<-EOF
+    {{message}}
+
+    Regards,
+    DALScooter Team
+  EOF
+}


### PR DESCRIPTION
I introduced a Cognito user group that embeds role information into the generated access token. On the client side, this token is stored in localStorage so that all user-specific data can be easily retrieved.

I also built a notification pipeline: messages are first published to SNS, then queued in SQS, and finally dispatched as emails via SES.

FROM EMAIL used in our group email